### PR TITLE
fix: environment compatibility for strict mode

### DIFF
--- a/install/environment.yml
+++ b/install/environment.yml
@@ -1,9 +1,8 @@
-name: rcrunch
+name: rcrunch1
 channels:
   - bioconda
   - conda-forge
-  - defaults
 dependencies:
-  - snakemake=7.2.1
-  - biopython=1.79
-  - tabulate=0.8.10
+  - bioconda::snakemake=7.2.1
+  - conda-forge::biopython=1.79
+  - conda-forge::tabulate=0.8.10

--- a/install/environment.yml
+++ b/install/environment.yml
@@ -1,4 +1,4 @@
-name: rcrunch1
+name: rcrunch
 channels:
   - bioconda
   - conda-forge


### PR DESCRIPTION
Added specific channels in the install/environment.yml to ensure that it is compatible with versions of conda that have strict channel priority as the default